### PR TITLE
changed-files won't work

### DIFF
--- a/.github/workflows/build-and-push-docker.yml
+++ b/.github/workflows/build-and-push-docker.yml
@@ -50,17 +50,10 @@ jobs:
             type=semver,pattern={{version}},value=${{steps.dotenv.outputs.version}}
             type=semver,pattern={{major}}.{{minor}},value=${{steps.dotenv.outputs.version}}
 
-      - name: Check .env file has changed for publication
-        id: dotenv-changed
-        uses: tj-actions/changed-files@v29.0.2
-        with:
-          files: |
-            docker/${{ matrix.image }}/.env
-
       - name: Build and push Docker image
         uses: docker/build-push-action@v3
         with:
           context: docker/${{ matrix.image }}/
-          push: ${{ github.event_name != 'pull_request' && steps.dotenv-changed.outputs.any_changed == 'true' }}
+          push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
I've done some testing on the owlot-test repo, but I can't get the tj-actions/changed-files action to work with checking if the .env file has been changed.
For now, just always publish a new image on merge to master. We can see how to optimize this later.