### PR TITLE
feat: add tarpaulin tool for coverage

### DIFF
--- a/.cspell.project-words.txt
+++ b/.cspell.project-words.txt
@@ -27,3 +27,5 @@ SSLMODE
 topk
 appenders
 psql
+RUSTFLAGS
+Ctarget

--- a/docker/arrow-rust/.env
+++ b/docker/arrow-rust/.env
@@ -1,1 +1,1 @@
-VERSION=v1.1.1
+VERSION=v1.1.2

--- a/docker/arrow-rust/Dockerfile
+++ b/docker/arrow-rust/Dockerfile
@@ -4,10 +4,15 @@ ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \
     PATH=/usr/local/cargo/bin:$PATH
 
-RUN apk add --no-cache musl-dev libc-dev pkgconfig openssl protoc protobuf-dev openssl-dev git && \
+RUN apk add --no-cache musl-dev libc-dev pkgconfig openssl \
+    protoc protobuf-dev openssl-dev git perl make && \
     # Add rust dependencies
     rustup target add x86_64-unknown-linux-musl && \
     rustup component add clippy && \
     rustup component add rustfmt
+
+ENV RUSTFLAGS="-Ctarget-feature=-crt-static"
+RUN cargo install cargo-tarpaulin
+ENV RUSTFLAGS=
 
 WORKDIR /usr/src/app


### PR DESCRIPTION
~NOTE: Tarpaulin requires `--security-opt seccomp=unconfined` docker option, investigating if this is going to be a security issue if we only use it in GitHub actions for coverage tests and NOT deployment~

~`cargo install` currently failing on `arm64` builds~

Requires the `RUSTFLAGS` for `cargo install`ed tools to not segfault: https://github.com/rust-lang/compiler-team/issues/422

Example:
https://github.com/Arrow-air/tf-github/pull/74/files

NOTE: An alternative, `grcov`, requires the nightly toolchain
