### PR TITLE
fix(docker): build error and workflow

### DIFF
--- a/.github/workflows/build-and-push-docker.yml
+++ b/.github/workflows/build-and-push-docker.yml
@@ -4,9 +4,13 @@ on:
   push:
     branches:
       - 'main'
+    paths:
+      - docker/**
   pull_request:
     branches:
       - 'main'
+    paths:
+      - docker/**
 
 env:
   REGISTRY: ghcr.io

--- a/docker/arrow-sanitychecks/Dockerfile
+++ b/docker/arrow-sanitychecks/Dockerfile
@@ -1,4 +1,4 @@
-FROM tamasfe/taplo:0.7.0-alpine AS taplo
+FROM tamasfe/taplo:0.8.0-alpine AS taplo
 
 FROM --platform=$TARGETPLATFORM rust:1.63-alpine3.16
 
@@ -14,7 +14,7 @@ RUN apk add --no-cache py3-pip openssl npm git && \
     # Add python dependencies
     pip install flake8==$FLAKE8_VERSION && \
     pip install flake8-bugbear && \
-    pip install flake8-black && \
+    pip install --ignore-installed flake8-black && \
     pip install yapf && \
     # Add cspell dependencies
     npm install -g cspell && \


### PR DESCRIPTION
Fixes docker build error on installation of the `flake8-black` plugin. It depends on the `packaging` package which is already installed in `distutils` but with an older version. This results in conflicts when `flake8-black` tries to update it to a newer version.
We've now added an ignore, so it won't try to uninstall the `packaging` package while installing `flake8-black`.

In addition, the Docker build and push workflow has been updated to only trigger if any of the docker files have been changed.