### PR TITLE
fix: fix tarpaulin failure

### DIFF
--- a/.github/workflows/build-and-push-docker.yml
+++ b/.github/workflows/build-and-push-docker.yml
@@ -43,6 +43,10 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
+        with:
+          config-inline: |
+            [worker.oci]
+              max-parallelism = 1
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v2
@@ -63,7 +67,7 @@ jobs:
             type=semver,pattern={{major}}.{{minor}},value=${{steps.dotenv.outputs.version}}
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v4
         with:
           context: docker/${{ matrix.image }}/
           push: ${{ github.event_name != 'pull_request' }}

--- a/docker/arrow-rust/.env
+++ b/docker/arrow-rust/.env
@@ -1,1 +1,1 @@
-VERSION=v1.1.2
+VERSION=v1.1.3

--- a/docker/arrow-rust/Dockerfile
+++ b/docker/arrow-rust/Dockerfile
@@ -1,8 +1,14 @@
-FROM rust:1.66-alpine3.16
+FROM rust:1.68-alpine
 
+ARG TARGETOS
+ARG TARGETARCH
+
+ENV BUILDX_ARCH="${TARGETOS:-linux}-${TARGETARCH:-amd64}"
 ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \
     PATH=/usr/local/cargo/bin:$PATH
+
+RUN echo "Building for $BUILDX_ARCH"
 
 RUN apk add --no-cache musl-dev libc-dev pkgconfig openssl \
     protoc protobuf-dev openssl-dev git perl make && \


### PR DESCRIPTION
Hopefully fix the arrow-rust docker build which keeps failing on the ARM64 image during the installation of cargo-tarpaulin.
Added BUILDX_ARCH env file and bumped base docker version