### PR TITLE
feat: change image from ubuntu lunar to arrow-rust

### DIFF
--- a/.cspell.project-words.txt
+++ b/.cspell.project-words.txt
@@ -42,3 +42,5 @@ TFENV
 tfenv
 libusb
 udev
+gmake
+newlib

--- a/docker/arrow-stm32/.env
+++ b/docker/arrow-stm32/.env
@@ -1,1 +1,1 @@
-VERSION=v1.0.0
+VERSION=v1.0.1

--- a/docker/arrow-stm32/Dockerfile
+++ b/docker/arrow-stm32/Dockerfile
@@ -1,33 +1,30 @@
-FROM ubuntu:lunar
+# Allow C and Rust STM32 Development
+FROM ghcr.io/arrow-air/tools/arrow-rust:1.1
 
-RUN apt-get update && \
-    apt-get clean && \
-    apt-get install -y \
-    build-essential \
+RUN apk add --no-cache \
     wget \
     curl \
-    git \
     libusb-dev \
     udev \
-    stlink-tools \
+    stlink \
+    gcc \
+    g++ \
+    newlib-arm-none-eabi \
     cmake
 
 ENV STM32_LIB_PATH=/home/stm32/lib/
-ENV ARM_WEBSITE https://developer.arm.com/-/media/Files/downloads/gnu-rm/
-ENV ARM_RELEASE=10.3-2021.10
 WORKDIR ${STM32_LIB_PATH}
 
 RUN git clone --depth=1 https://github.com/STMicroelectronics/STM32CubeF4
 RUN git clone --depth=1 https://github.com/STMicroelectronics/STM32CubeH7
 RUN git clone https://github.com/ObKo/stm32-cmake
 
-RUN wget -qO- ${ARM_WEBSITE}/${ARM_RELEASE}/gcc-arm-none-eabi-${ARM_RELEASE}-x86_64-linux.tar.bz2 | tar -xj
-
 ENV STM32_CMAKE_PATH=${STM32_LIB_PATH}/stm32-cmake/cmake/
-ENV STM32_TOOLCHAIN_PATH=${STM32_LIB_PATH}/gcc-arm-none-eabi-${ARM_RELEASE}/bin
+ENV STM32_TOOLCHAIN_PATH=/usr/bin/
 ENV STM32_TARGET_TRIPLET=arm-none-eabi
 ENV STM32_CUBE_F4_PATH=${STM32_LIB_PATH}/STM32CubeF4
 ENV STM32_CUBE_H7_PATH=${STM32_LIB_PATH}/STM32CubeH7
 ENV PATH=$PATH:${STM32_TOOLCHAIN_PATH}
 
+RUN ln -s /usr/bin/make /usr/bin/gmake
 WORKDIR /usr/src/app


### PR DESCRIPTION
Switch arrow-stm32 FROM image ubuntu:lunar to arrow-rust:1.1

Reasons:
- arrow-rust is based on an alpine image which is overall much smaller than ubuntu:lunar
- stm32-rs and stm32 rust HALs are gaining potential and using arrow-rust as a base image allows us to do stm32 rust projects in the future