### PR TITLE
chore: upgrade rust version

### DIFF
--- a/docker/arrow-rust/.env
+++ b/docker/arrow-rust/.env
@@ -1,1 +1,1 @@
-VERSION=v1.1.3
+VERSION=v1.2.0

--- a/docker/arrow-rust/Dockerfile
+++ b/docker/arrow-rust/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.68-alpine
+FROM rust:1.73-alpine
 
 ARG TARGETOS
 ARG TARGETARCH
@@ -6,7 +6,8 @@ ARG TARGETARCH
 ENV BUILDX_ARCH="${TARGETOS:-linux}-${TARGETARCH:-amd64}"
 ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \
-    PATH=/usr/local/cargo/bin:$PATH
+    PATH=/usr/local/cargo/bin:$PATH \
+    OPENSSL_DIR=/usr
 
 RUN echo "Building for $BUILDX_ARCH"
 
@@ -19,7 +20,7 @@ RUN apk add --no-cache musl-dev libc-dev pkgconfig openssl \
     rustup component add clippy && \
     rustup component add rustfmt && \
     # Use binary install for tarpaulin to bypass build OOM error
-    wget https://github.com/xd009642/tarpaulin/releases/download/0.25.1/cargo-tarpaulin-${ARCHITECTURE}.tar.gz && \
+    wget https://github.com/xd009642/tarpaulin/releases/download/0.27.1/cargo-tarpaulin-${ARCHITECTURE}.tar.gz && \
     tar axvf cargo-tarpaulin-${ARCHITECTURE}.tar.gz && \
     mv cargo-tarpaulin $CARGO_HOME/bin/ && \
     rm cargo-tarpaulin-${ARCHITECTURE}.tar.gz

--- a/docker/arrow-sanitychecks/.env
+++ b/docker/arrow-sanitychecks/.env
@@ -1,1 +1,1 @@
-VERSION=v0.2.0
+VERSION=v0.3.0

--- a/docker/arrow-sanitychecks/Dockerfile
+++ b/docker/arrow-sanitychecks/Dockerfile
@@ -1,6 +1,6 @@
-FROM tamasfe/taplo:0.8.0-alpine AS taplo
+FROM tamasfe/taplo:0.8.1-alpine AS taplo
 
-FROM --platform=$TARGETPLATFORM rust:1.63-alpine3.16
+FROM --platform=$TARGETPLATFORM rust:1.73-alpine
 
 
 ENV RUSTUP_HOME=/usr/local/rustup \


### PR DESCRIPTION
In preparation of R4, we should start with updating all versions where possible.
This PR will upgrade the rust version in our rust dockers. In addition, it will make sure we're using the latest versions of other dependencies used in these docker files.